### PR TITLE
Implement some Dark API functions

### DIFF
--- a/zluda/src/impl/dark_api.rs
+++ b/zluda/src/impl/dark_api.rs
@@ -62,6 +62,31 @@ impl CudaDarkApi for CudaDarkApiZluda {
         device::primary_ctx_get(pctx, hip_dev).into_cuda()
     }
 
+    unsafe extern "system" fn set_device_flags(
+        dev: cuda_types::CUdevice,
+        flags: c_uint,
+    ) -> CUresult {
+        use hip_runtime_sys::*;
+        let hip_dev = FromCuda::from_cuda(dev);
+        let mut active_dev = 0i32;
+        hipGetDevice(&mut active_dev as _);
+        if hip_dev != active_dev {
+            hipSetDevice(hip_dev);
+        }
+        let res = hipSetDeviceFlags(flags).into_cuda();
+        if hip_dev != active_dev {
+            hipSetDevice(active_dev);
+        }
+        res
+    }
+
+    unsafe extern "system" fn set_device(
+        dev: cuda_types::CUdevice,
+    ) -> CUresult {
+        use hip_runtime_sys::*;
+        hipSetDevice(FromCuda::from_cuda(dev)).into_cuda()
+    }
+
     unsafe extern "system" fn get_module_from_cubin_ex1(
         module: *mut cuda_types::CUmodule,
         fatbinc_wrapper: *const zluda_dark_api::FatbincWrapper,
@@ -187,19 +212,24 @@ impl CudaDarkApi for CudaDarkApiZluda {
         context::create(pctx, flags, dev).into_cuda()
     }
 
-    unsafe extern "system" fn heap_alloc(
-        _halloc_ptr: *mut *mut zluda_dark_api::HeapAllocRecord,
-        _param1: usize,
-        _param2: usize,
+    // These two functions are stubs that only implement add/remove functionality and nothing else
+    unsafe extern "system" fn list_add(
+        precord: *mut *mut zluda_dark_api::ListRecord,
+        _func: *const c_void,
+        data: usize,
     ) -> CUresult {
-        super::unimplemented()
+        *(precord as *mut usize) = data;
+        CUresult::CUDA_SUCCESS
     }
 
-    unsafe extern "system" fn heap_free(
-        _halloc: *mut zluda_dark_api::HeapAllocRecord,
-        _param2: *mut usize,
+    unsafe extern "system" fn list_remove(
+        record: *mut zluda_dark_api::ListRecord,
+        pdata: *mut usize,
     ) -> CUresult {
-        super::unimplemented()
+        if pdata != ptr::null_mut() {
+            *pdata = record as usize;
+        }
+        CUresult::CUDA_SUCCESS
     }
 
     unsafe extern "system" fn device_get_attribute_ex(

--- a/zluda/src/impl/dark_api.rs
+++ b/zluda/src/impl/dark_api.rs
@@ -69,13 +69,19 @@ impl CudaDarkApi for CudaDarkApiZluda {
         use hip_runtime_sys::*;
         let hip_dev = FromCuda::from_cuda(dev);
         let mut active_dev = 0i32;
-        hipGetDevice(&mut active_dev as _);
+        let res = hipGetDevice(&mut active_dev as _).into_cuda();
+        if res != CUresult::CUDA_SUCCESS {
+            return res;
+        }
         if hip_dev != active_dev {
-            hipSetDevice(hip_dev);
+            let res = hipSetDevice(hip_dev).into_cuda();
+            if res != CUresult::CUDA_SUCCESS {
+                return res;
+            }
         }
         let res = hipSetDeviceFlags(flags).into_cuda();
         if hip_dev != active_dev {
-            hipSetDevice(active_dev);
+            let _ = hipSetDevice(active_dev);
         }
         res
     }

--- a/zluda_dark_api/src/lib.rs
+++ b/zluda_dark_api/src/lib.rs
@@ -196,7 +196,7 @@ macro_rules! dark_api_table {
 
 dark_api_table!(
     [0x6b, 0xd5, 0xfb, 0x6c, 0x5b, 0xf4, 0xe7, 0x4a, 0x89, 0x87, 0xd9, 0x39, 0x12, 0xfd, 0x9d, 0xf9]
-    => CUDART_INTERFACE [10] {
+    => CUDART_INTERFACE [12] {
         0 => SIZE_OF,
         #[dump]
         1 => get_module_from_cubin(
@@ -204,6 +204,8 @@ dark_api_table!(
             fatbinc_wrapper: *const FatbincWrapper
         ) -> CUresult,
         2 => get_primary_context(pctx: *mut CUcontext, dev: CUdevice) -> CUresult,
+        4 => set_device_flags(dev: CUdevice, flags: c_uint) -> CUresult,
+        5 => set_device(dev: CUdevice) -> CUresult,
         #[dump]
         6 => get_module_from_cubin_ex1(
             module: *mut CUmodule,
@@ -285,12 +287,12 @@ dark_api_table!(
     [0x19, 0x5B, 0xCB, 0xF4, 0xD6, 0x7D, 0x02, 0x4A, 0xAC, 0xC5, 0x1D, 0x29, 0xCE, 0xA6, 0x31, 0xAE]
     => HEAP_ACCESS [3] {
         0 => SIZE_OF,
-        1 => heap_alloc(
-            halloc_ptr: *mut *mut HeapAllocRecord,
-            param1: usize,
-            param2: usize
+        1 => list_add(
+            precord: *mut *mut ListRecord,
+            func: *const c_void,
+            data: usize
         ) -> CUresult,
-        2 => heap_free(halloc: *mut HeapAllocRecord, param2: *mut usize) -> CUresult
+        2 => list_remove(record: *mut ListRecord, pdata: *mut usize) -> CUresult
     },
     // This fn table is used by OptiX
     [0xB1u8, 0x05, 0x41, 0xE1, 0xF7, 0xC7, 0xC7, 0x4A, 0x9F, 0x64, 0xF2, 0x23, 0xBE, 0x99, 0xF1, 0xE2]
@@ -486,11 +488,11 @@ pub enum ContextState {}
 pub enum ContextStateManager {}
 
 #[repr(C)]
-pub struct HeapAllocRecord {
-    param1: usize,
-    param2: usize,
-    _unknown: usize,
-    global_heap: *mut c_void,
+pub struct ListRecord {
+    func: *const c_void,
+    data: usize,
+    prev: *mut ListRecord,
+    next: *mut ListRecord,
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
The functions that are required for CUDA runtime 6.5 and 7.0. Now CUDA-Z is able to run memory bench.

Compute bench fails on

> Unrecognized statement `mul24.lo.s32 %r8, %r7, %r7;` found at 641406:641433

and I don't understand how to add a new command to ptx translator.

Thank you for continuing ROCm5 support, as version 6 dropped support of my GPU.