### PR TITLE
ZLUDA v3.9.2

### DIFF
--- a/zluda/src/cuda.rs
+++ b/zluda/src/cuda.rs
@@ -140,6 +140,8 @@ cuda_function_declarations!(
         cuPointerGetAttributes,
         cuStreamCreate,
         cuStreamCreateWithPriority,
+        cuStreamBeginCapture_v2,
+        cuStreamEndCapture,
         cuStreamGetCaptureInfo,
         cuStreamGetCtx,
         cuStreamGetCtx_ptsz,
@@ -195,12 +197,14 @@ cuda_function_declarations!(
         cuEventRecord,
         cuEventRecord_ptsz,
         cuEventSynchronize,
+        cuGraphGetNodes,
         cuGraphAddDependencies,
         cuGraphAddEmptyNode,
         cuGraphAddKernelNode,
         cuGraphCreate,
         cuGraphDestroy,
         cuGraphExecDestroy,
+        cuGraphInstantiateWithFlags,
         cuGraphInstantiate,
         cuGraphInstantiate_v2,
         cuGraphLaunch,
@@ -1059,6 +1063,20 @@ mod definitions {
         stream::create_with_priority(phStream, flags, priority)
     }
 
+    pub(crate) unsafe fn cuStreamBeginCapture_v2(
+        stream: *mut stream::Stream,
+        mode: hipStreamCaptureMode,
+    ) -> Result<(), CUresult> {
+        stream::begin_capture(stream, mode)
+    }
+
+    pub(crate) unsafe fn cuStreamEndCapture(
+        stream: *mut stream::Stream,
+        phGraph: *mut hipGraph_t,
+    ) -> Result<(), CUresult> {
+        stream::end_capture(stream, phGraph)
+    }
+
     pub(crate) unsafe fn cuStreamGetCaptureInfo(
         stream: *mut stream::Stream,
         captureStatus_out: *mut hipStreamCaptureStatus,
@@ -1487,6 +1505,14 @@ mod definitions {
         hipEventSynchronize(event)
     }
 
+    pub(crate) unsafe fn cuGraphGetNodes(
+        graph: hipGraph_t,
+        nodes: *mut hipGraphNode_t,
+        numNodes: *mut usize,
+    ) -> hipError_t {
+        hipGraphGetNodes(graph, nodes, numNodes)
+    }
+
     pub(crate) unsafe fn cuGraphAddDependencies(
         graph: hipGraph_t,
         from: *const hipGraphNode_t,
@@ -1534,6 +1560,14 @@ mod definitions {
 
     pub(crate) unsafe fn cuGraphExecDestroy(graphExec: hipGraphExec_t) -> hipError_t {
         hipGraphExecDestroy(graphExec)
+    }
+
+    pub(crate) unsafe fn cuGraphInstantiateWithFlags(
+        phGraphExec: *mut hipGraphExec_t,
+        hGraph: hipGraph_t,
+        flags: ::std::os::raw::c_ulonglong,
+    ) -> hipError_t {
+        hipGraphInstantiateWithFlags(phGraphExec, hGraph, flags)
     }
 
     pub(crate) unsafe fn cuGraphInstantiate(

--- a/zluda/src/cuda.rs
+++ b/zluda/src/cuda.rs
@@ -151,6 +151,7 @@ cuda_function_declarations!(
         cuStreamQuery,
         cuStreamSynchronize,
         cuStreamSynchronize_ptsz,
+        cuThreadExchangeStreamCaptureMode,
         cuStreamDestroy,
         cuStreamDestroy_v2,
         cuStreamWaitEvent,
@@ -1132,6 +1133,12 @@ mod definitions {
         hStream: *mut stream::Stream,
     ) -> Result<(), CUresult> {
         stream::synchronize(hStream, true)
+    }
+
+    pub(crate) unsafe fn cuThreadExchangeStreamCaptureMode(
+        mode: *mut hipStreamCaptureMode,
+    ) -> Result<(), CUresult> {
+        stream::thread_exchange_capture_mode(mode)
     }
 
     pub(crate) unsafe fn cuStreamDestroy(hStream: *mut stream::Stream) -> Result<(), CUresult> {

--- a/zluda/src/impl/mod.rs
+++ b/zluda/src/impl/mod.rs
@@ -251,6 +251,7 @@ impl FromCuda<CUgraphExec> for hipGraphExec_t {}
 impl FromCuda<CUgraphicsResource> for hipGraphicsResource_t {}
 impl FromCuda<CUlimit> for hipLimit_t {}
 impl FromCuda<CUsurfObject> for hipSurfaceObject_t {}
+impl FromCuda<CUstreamCaptureMode> for hipStreamCaptureMode {}
 
 impl<From, Into: FromCuda<From>> FromCuda<*mut From> for *mut Into {}
 impl<From, Into: FromCuda<From>> FromCuda<*const From> for *const Into {}

--- a/zluda/src/impl/stream.rs
+++ b/zluda/src/impl/stream.rs
@@ -108,6 +108,13 @@ pub(crate) unsafe fn synchronize(
     Ok(())
 }
 
+pub(crate) unsafe fn thread_exchange_capture_mode(
+    mode: *mut hipStreamCaptureMode,
+) -> Result<(), CUresult> {
+    hip_call_cuda!(hipThreadExchangeStreamCaptureMode(mode));
+    Ok(())
+}
+
 pub(crate) unsafe fn destroy(stream: *mut Stream) -> Result<(), CUresult> {
     if as_default_stream(stream).is_some() {
         return Err(CUresult::CUDA_ERROR_INVALID_VALUE);

--- a/zluda/src/impl/stream.rs
+++ b/zluda/src/impl/stream.rs
@@ -67,6 +67,24 @@ pub(crate) unsafe fn create_with_priority(
     Ok(())
 }
 
+pub(crate) unsafe fn begin_capture(
+    stream: *mut Stream,
+    mode: hipStreamCaptureMode,
+) -> Result<(), CUresult> {
+    let hip_stream = as_hip_stream(stream)?;
+    hip_call_cuda! { hipStreamBeginCapture(hip_stream, mode) };
+    Ok(())
+}
+
+pub(crate) unsafe fn end_capture(
+    stream: *mut Stream,
+    p_graph: *mut hipGraph_t,
+) -> Result<(), CUresult> {
+    let hip_stream = as_hip_stream(stream)?;
+    hip_call_cuda! { hipStreamEndCapture(hip_stream, p_graph) };
+    Ok(())
+}
+
 pub(crate) unsafe fn get_ctx(
     stream: *mut Stream,
     pctx: *mut *mut context::Context,

--- a/zluda_inject/src/bin.rs
+++ b/zluda_inject/src/bin.rs
@@ -83,7 +83,7 @@ pub fn main_impl() -> Result<(), Box<dyn Error>> {
         match argument.to_str() {
             Some(argument) => match argument {
                 "--version" => {
-                    println!("ZLUDA 3.9.0");
+                    println!("ZLUDA 3.9.2");
                     process::exit(0);
                 }
                 "--" => break,


### PR DESCRIPTION
## Change logs

- [Driver/Stream] Add cuStreamBeginCapture_v2.
- [Driver/Stream] Add cuStreamEndCapture.
- [Driver/Stream] Add cuThreadExchangeStreamCaptureMode.
- [Driver/Graph] Add cuGraphGetNodes.
- [Driver/Graph] Add cuGraphInstantiateWithFlags.

From ZLUDA v3.9.2, `torch.compile()` inductor and cuda_graph is now available.
(using [custom triton](https://github.com/lshqqytiger/triton))